### PR TITLE
Fixed invalid JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Currently it looks for a files called dynamicReturnTypeMeta.json anywhere in the
             "class": "\\Phockito",
             "method": "verify",
             "position": 0
-        },
+        }
     ],
     "functionCalls": [
         {


### PR DESCRIPTION
I noticed a trailing comma in the example JSON within the README.md.